### PR TITLE
Introduce runMulti that can take filenames and code strings mixed togeth...

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -106,7 +106,7 @@ var Context = function (template) {
         },
 
         runFile: function (fileName, callback) {
-            runFiles([fileName], callback);
+            runMulti([fileName], callback);
             fs.readFile(
                 fileName,
                 'utf8',


### PR DESCRIPTION
...er.

On the server side, it can be convenient to provide the JS code to run as string
instead of file to read on the disk.
It is also very convenient to be able to mix the two types.
