### PR TITLE
use graceful-fs to avoid too many open files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var jsdom = require('jsdom');
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var Context = function (template) {
     // We provide an empty DOM that allows some basic parts of AngularJS to work,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         }
     ],
     "dependencies": {
-        "jsdom": "~0.8.6"
+        "jsdom": "~0.8.6",
+        "graceful-fs": "~2.0.3"
     },
     "devDependencies": {
         "nodeunit": "*",


### PR DESCRIPTION
This is a common module to avoid the "Error: EMFILE, too many open files" situation. In one project, we're running many contexts and seeing this error often.
