### PR TITLE
Added registerConsole()

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -124,6 +124,10 @@ var Context = function (template) {
         hasRequire: function () {
             return typeof rawContext.require === 'object';
         },
+        
+		registerConsole: function() {
+			rawContext.console = console;
+		},
 
         getRequire: function () {
             return rawContext.require;


### PR DESCRIPTION
This method allows console calls in the context to be forwarded to the parent context (i.e. the Node console).